### PR TITLE
TYPO3 6.2 quickfix

### DIFF
--- a/src/typo3/imagewidthspecificationwizard/class.tx_imagewidthspecificationwizard_wizard.php
+++ b/src/typo3/imagewidthspecificationwizard/class.tx_imagewidthspecificationwizard_wizard.php
@@ -39,7 +39,9 @@
  *
  */
 
-require_once(PATH_t3lib.'class.t3lib_befunc.php');
+if(defined('PATH_t3lib')) {	
+	require_once(PATH_t3lib . 'class.t3lib_befunc.php');
+}
 require_once(t3lib_extMgm::extPath('lang','lang.php'));
 
 /**


### PR DESCRIPTION
This should actually make the ext compatible to TYPO3 6.2.
